### PR TITLE
fix for trailing slash

### DIFF
--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -8,6 +8,6 @@ from .views import SwaggerView, ResourcesView, SchemaView
 urlpatterns = patterns('',
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
-    url(r'^schema/(?P<resource>\S+)/$', SchemaView.as_view()),
+    url(r'^schema/(?P<resource>\S+)', SchemaView.as_view()),
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
 )


### PR DESCRIPTION
Remove the trailing slash - the urls that swagger javascript produce don't include them, so this package was not working for users that had `settings.APPEND_SLASH=False`.

For users with `settings.APPEND_SLASH=True`, it was working because Django was issuing a redirect, so this should save an HTTP request.
